### PR TITLE
Added port retries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import { downloadBinary } from './libraries/Downloader'
 
 const defaultOptions: InternalServerOptions = {
     dbName: 'dbdata',
-    logLevel: 'LOG'
+    logLevel: 'LOG',
+    portRetries: 10
 }
 
 process.on('exit', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -5,13 +5,15 @@ export type LOG_LEVEL = 'LOG' | 'WARN' | 'ERROR'
 export type ServerOptions = {
     version?: string,
     dbName: string,
-    loglevel?: LOG_LEVEL
+    loglevel?: LOG_LEVEL,
+    portRetries?: number
 }
 
 export type InternalServerOptions = {
     version?: string,
     dbName: string,
-    logLevel: LOG_LEVEL
+    logLevel: LOG_LEVEL,
+    portRetries: number
 }
 
 export type ExecutorOptions = {


### PR DESCRIPTION
If a MySQL or MySQLX port is generated that is already being used, new ports can be generated to be used again. A `portRetries` option has been added so people can set the maximum amount of retries for ports before giving up.

Ideally you would use port 0 for these sorts of things, but according to MySQL docs, port 0 will use the MySQL default port (3306) so a random number generator has been used for the ports instead.