### PR TITLE
Fix port retries

### DIFF
--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -40,6 +40,11 @@ class Executor {
             let resolveFunction: () => void;
 
             process.on('close', async (code, signal) => {
+                const errorString = errors.join('\n')
+                if (errorString.includes('Address already in use')) {
+                    return reject('Port is already in use')
+                }
+
                 try {
                     await fsPromises.rm(dbPath, {recursive: true, force: true})
                     if (binaryFilepath.includes(os.tmpdir()) && !options.downloadBinaryOnce) {
@@ -60,13 +65,8 @@ class Executor {
                         return reject('Database exited early')
                     }
     
-                    const errorString = errors.join('\n')
-                    this.logger.error(errorString)
-                    if (errorString.includes('Address already in use')) {
-                        return reject('Port is already in use')
-                    }
-    
                     if (code) {
+                        this.logger.error(errorString)
                         return reject(errorString)
                     }
                 }


### PR DESCRIPTION
This pull request closes #37

## Summary and Motivation

Before this pull request, whenever the database closed the data directory would be deleted no matter what. This made the database crash after listening on a different randomly generated port after the first randomly generated port was already in use because the data directory selected was deleted. The data directory should only get deleted on unrecoverable errors and on clean exits. This pull request stops the data directory from being deleted if the error was from listening to a port that is in use.

## Type of change

- [x] Bug Fix

## Checklist
Please make sure these steps are completed, or delete any irrelevant steps.

- [x] I have self-reviewed my code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch