### PR TITLE
added dbPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Gotchas: This option is intended to be for internal debugging purposes only and 
 
 Description: Changes whether or not the database will be deleted after it has been stopped. If set to `true`, the database WILL be deleted after it has been stopped.
 
+- `dataPath: string`
+
+Required: No
+
+Default: `TMPDIR/mysqlmsn/dbs/UUID` (replacing TMPDIR with the OS temp directory and UUID with a UUIDv4 without seperating dashes)
+
+Gotchas: This option is intended to be for internal debugging purposes only and not meant for people to use. As such, this option will not follow Semantic Versioning.
+
+Description: The folder to store database-related data in
+
 ## If using Ubuntu 24.04 and newer
 
 Selecting what MySQL version to use is not currently supported on Ubuntu 24.04 and newer. To use this package on Ubuntu 24.04 and newer you must have the `mysql-server` package installed on your system and `ServerOptions.version` must either be the version that is installed on the system or undefined.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,27 @@ import { BinaryInfo, InternalServerOptions, ServerOptions } from '../types'
 import getBinaryURL from './libraries/Version'
 import MySQLVersions from './versions.json'
 import { downloadBinary } from './libraries/Downloader'
-
-const defaultOptions: InternalServerOptions = {
-    dbName: 'dbdata',
-    logLevel: 'ERROR',
-    portRetries: 10,
-    downloadBinaryOnce: true,
-    lockRetries: 1_000,
-    lockRetryWait: 1_000,
-    username: 'root',
-    deleteDBAfterStopped: true
-}
+import { randomUUID } from "crypto";
+import {normalize as normalizePath} from 'path'
 
 process.on('exit', () => {
     DBDestroySignal.abort('Process is exiting')
 })
 
-export async function createDB(opts: ServerOptions = defaultOptions) {
+export async function createDB(opts?: ServerOptions) {
+    const defaultOptions: InternalServerOptions = {
+        dbName: 'dbdata',
+        logLevel: 'ERROR',
+        portRetries: 10,
+        downloadBinaryOnce: true,
+        lockRetries: 1_000,
+        lockRetryWait: 1_000,
+        username: 'root',
+        deleteDBAfterStopped: true,
+        //mysqlmsn = MySQL Memory Server Node.js
+        dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`)
+    }
+    
     const options: InternalServerOptions = {...defaultOptions, ...opts}
 
     const logger = new Logger(options.logLevel)

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -8,7 +8,6 @@ import { GenerateRandomPort } from "./Port";
 import DBDestroySignal from "./AbortSignal";
 import { ExecuteReturn, InstalledMySQLVersion, InternalServerOptions, MySQLDB } from "../../types";
 import {normalize as normalizePath} from 'path'
-import { randomUUID } from "crypto";
 
 class Executor {
     logger: Logger;
@@ -186,9 +185,7 @@ class Executor {
 
     startMySQL(options: InternalServerOptions, binaryFilepath: string): Promise<MySQLDB> {
         return new Promise(async (resolve, reject) => {
-            //mysqlmsn = MySQL Memory Server Node.js
-            const dbPath = normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`)
-            const datadir = normalizePath(`${dbPath}/data`)
+            const datadir = normalizePath(`${options.dbPath}/data`)
 
             this.logger.log('Created data directory for database at:', datadir)
             await fsPromises.mkdir(datadir, {recursive: true})
@@ -215,7 +212,7 @@ class Executor {
                 initText += `RENAME USER 'root'@'localhost' TO '${options.username}'@'localhost';`
             }
 
-            await fsPromises.writeFile(`${dbPath}/init.sql`, initText, {encoding: 'utf8'})
+            await fsPromises.writeFile(`${options.dbPath}/init.sql`, initText, {encoding: 'utf8'})
 
             let retries = 0;
 
@@ -225,7 +222,7 @@ class Executor {
                 this.logger.log('Using port:', port, 'on retry:', retries)
 
                 try {
-                    const resolved = await this.#startMySQLProcess(options, port, mySQLXPort, datadir, dbPath, binaryFilepath)
+                    const resolved = await this.#startMySQLProcess(options, port, mySQLXPort, datadir, options.dbPath, binaryFilepath)
                     return resolve(resolved)
                 } catch (e) {
                     if (e !== 'Port is already in use') {

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -9,7 +9,7 @@ let db: MySQLDB;
 let connection: sql.Connection;
 
 beforeEach(async () => {
-    db = await createDB({username: ''})
+    db = await createDB({username: '', logLevel: 'LOG', dbPath: '/Users/sebastianwebster/Downloads/loldb'})
     connection = await sql.createConnection({
         host: '127.0.0.1',
         port: db.port

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,7 +11,8 @@ export type ServerOptions = {
     lockRetries?: number,
     lockRetryWait?: number,
     username?: string,
-    deleteDBAfterStopped?: boolean
+    deleteDBAfterStopped?: boolean,
+    dbPath?: string
 }
 
 export type InternalServerOptions = {
@@ -23,7 +24,8 @@ export type InternalServerOptions = {
     lockRetries: number,
     lockRetryWait: number,
     username: string,
-    deleteDBAfterStopped: boolean
+    deleteDBAfterStopped: boolean,
+    dbPath: string
 }
 
 export type ExecutorOptions = {


### PR DESCRIPTION
This pull request closes #40

## Summary and Motivation

An option called `dbPath` was added that allows you to change the path of the database directory. This is meant to only be used for CI purposes and users of this package should leave this option as the default value. Since this option is only meant for internal debugging purposes, it will not follow Semantic Versioning practices.

## Type of change

- [x] Adding A Feature

## Checklist

- [x] I have self-reviewed my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my change works
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch