### PR TITLE
Fix race condition for resolve for `createDB()`

### DIFF
--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -31,7 +31,7 @@ class Executor {
         return new Promise(async (resolve, reject) => {
             await fsPromises.rm(logFile, {force: true})
 
-            const process = spawn(binaryFilepath, ['--no-defaults', `--port=${port}`, `--datadir=${datadir}`, `--mysqlx-port=${mySQLXPort}`, `--mysqlx-socket=${dbPath}/x.sock`, `--socket=${dbPath}/m.sock`, `--general-log-file=${logFile}`, '--general-log=1', `--init-file=${dbPath}/init.sql`, '--bind-address=127.0.0.1', '--innodb-doublewrite=OFF'], {signal: DBDestroySignal.signal, killSignal: 'SIGKILL'})
+            const process = spawn(binaryFilepath, ['--no-defaults', `--port=${port}`, `--datadir=${datadir}`, `--mysqlx-port=${mySQLXPort}`, `--mysqlx-socket=${dbPath}/x.sock`, `--socket=${dbPath}/m.sock`, `--general-log-file=${logFile}`, '--general-log=1', `--init-file=${dbPath}/init.sql`, '--bind-address=127.0.0.1', '--innodb-doublewrite=OFF', '--console'], {signal: DBDestroySignal.signal, killSignal: 'SIGKILL'})
 
             //resolveFunction is the function that will be called to resolve the promise that stops the database.
             //If resolveFunction is not undefined, the database has received a kill signal and data cleanup procedures should run.

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -78,20 +78,7 @@ class Executor {
 
             process.stderr.on('data', (data) => {
                 if (!resolveFunction) {
-                    if (Buffer.isBuffer(data)) {
-                        errors.push(data.toString())
-                    } else {
-                        errors.push(data)
-                    }
-                }
-            })
-
-            fs.watchFile(logFile, async (curr) => {
-                if (curr.dev !== 0) {
-                    //File exists
-                    const file = await fsPromises.readFile(logFile, {encoding: 'utf8'})
-                    if (file.includes('started with:')) {
-                        fs.unwatchFile(logFile)
+                    if (String(data).includes('ready for connections. Version:')) {
                         resolve({
                             port,
                             xPort: mySQLXPort,
@@ -118,6 +105,13 @@ class Executor {
                                 })
                             }
                         })
+                    }
+
+                    
+                    if (Buffer.isBuffer(data)) {
+                        errors.push(data.toString())
+                    } else {
+                        errors.push(data)
                     }
                 }
             })


### PR DESCRIPTION
This pull request closes #42

## Summary and Motivation

The explanation can be found in #42. A race condition was caused that would make CI sometimes fail. This pull request changes what the executor is looking for in the logs before it resolves the function to fix the race condition.

## Type of change

- [x] Bug Fix

## Checklist

- [x] I have self-reviewed my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch