### PR TITLE
Expanded test matrix to lowest supported version of Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
         # We only support Node.js 16 and newer
-        node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
+        node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request closes #52

## Summary and Motivation

Motivation is explained in #52. This pull request adds Node version 16.6.0 and 17.0.0 to the test matrix.