### PR TITLE
Add informative MySQL out of date error

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Default: undefined
 Description: Version of MySQL to use for the database. Uses semver for getting the version, so valid semver versions are allowed. For example, `8.x` is a valid version and will use the latest 8.x MySQL version. 
 
 If left undefined:
-- If the system has MySQL installed, the system-installed version will be used. If the installed version is not supported by this package (currently <8.0.20), an error will be thrown unless `ignoreOutdatedSystemVersion` is set to `true`.
+- If the system has MySQL installed, the system-installed version will be used. If the installed version is not supported by this package (currently <8.0.20), an error will be thrown unless `ignoreUnsupportedSystemVersion` is set to `true`.
 - If the system does not have MySQL installed, the latest version of MySQL in the `versions.json` file in this package will be downloaded.
 
 If defined:
@@ -142,7 +142,7 @@ Default: root
 
 Description: The username of the user that is used to login to the database.
 
-- `ignoreOutdatedSystemVersion: boolean`
+- `ignoreUnsupportedSystemVersion: boolean`
 
 Required: No
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ Default: root
 
 Description: The username of the user that is used to login to the database.
 
+- `ignoreOutdatedSystemVersion: boolean`
+
+Required: No
+
+Default: false
+
+Description: This option only applies if the system-installed MySQL version is lower than the oldest supported MySQL version for this package (8.0.20). If set to `true`, this package will use the latest version of MySQL instead of the system-installed version. If `false`, the package will throw an error.
+
 - `deleteDBAfterStopped: boolean`
 
 Required: No

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ Default: undefined
 
 Description: Version of MySQL to use for the database. Uses semver for getting the version, so valid semver versions are allowed. For example, `8.x` is a valid version and will use the latest 8.x MySQL version. 
 
-If left undefined and the system has MySQL already installed, the system installed version of MySQL will be used. If left undefined and the system does not have MySQL installed, the latest version of MySQL in the `versions.json` file in this package will be downloaded. If defined and the system has that version of MySQL installed, the system installed version will be used. If defined and the system does not have that version of MySQL installed, that version will be downloaded as long as it is found in the `versions.json` file in this package.
+If left undefined:
+- If the system has MySQL installed, the system-installed version will be used. If the installed version is not supported by this package (currently <8.0.20), an error will be thrown unless `ignoreOutdatedSystemVersion` is set to `true`.
+- If the system does not have MySQL installed, the latest version of MySQL in the `versions.json` file in this package will be downloaded.
+
+If defined:
+- If the version is 8.0.19 or older, an error will be thrown as this package does not currently support those versions of MySQL.
+- If MySQL is installed on the system, the installed version will be used. Otherwise the selected version will be downloaded from the MySQL CDN as long as it can be found in the `versions.json` file. If it cannot be found in that file, an error will be thrown.
 
 - `dbName: string`
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+const CONSTANTS = {
+    MIN_SUPPORTED_MYSQL: '8.0.20'
+}
+
+export default CONSTANTS

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export async function createDB(opts?: ServerOptions) {
     if (options.version && lt(options.version, CONSTANTS.MIN_SUPPORTED_MYSQL)) {
         //The difference between the throw here and the throw above is this throw is because the selected "version" is not supported.
         //The throw above is because the system-installed MySQL is out of date and "ignoreOutdatedSystemVersion" is not set to true.
-        throw `The selected version of MySQL ${options.version} is not currently supported by this package. Please choose a different version to use.`
+        throw `The selected version of MySQL (${options.version}) is not currently supported by this package. Please choose a different version to use.`
     }
 
     logger.log('Version currently installed:', version)

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ export async function createDB(opts?: ServerOptions) {
         throw `A version of MySQL is installed on your system that is not supported by this package. If you want to download a MySQL binary instead of getting this error, please set the option "ignoreOutdatedSystemVersion" to true.`
     }
 
+    if (options.version && lt(options.version, CONSTANTS.MIN_SUPPORTED_MYSQL)) {
+        //The difference between the throw here and the throw above is this throw is because the selected "version" is not supported.
+        //The throw above is because the system-installed MySQL is out of date and "ignoreOutdatedSystemVersion" is not set to true.
+        throw `The selected version of MySQL ${options.version} is not currently supported by this package. Please choose a different version to use.`
+    }
+
     logger.log('Version currently installed:', version)
     if (version === null || (options.version && !satisfies(version.version, options.version)) || unsupportedMySQLIsInstalled) {
         let binaryInfo: BinaryInfo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export async function createDB(opts?: ServerOptions) {
 
     const unsupportedMySQLIsInstalled = version && lt(version.version, CONSTANTS.MIN_SUPPORTED_MYSQL)
 
-    const throwUnsupportedError = unsupportedMySQLIsInstalled && !options.ignoreOutdatedSystemVersion
+    const throwUnsupportedError = unsupportedMySQLIsInstalled && !options.ignoreOutdatedSystemVersion && !options.version
 
     if (throwUnsupportedError) {
         throw `A version of MySQL is installed on your system that is not supported by this package. If you want to download a MySQL binary instead of getting this error, please set the option "ignoreOutdatedSystemVersion" to true.`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Logger from './libraries/Logger'
 import * as os from 'node:os'
 import Executor from "./libraries/Executor"
-import { satisfies } from "semver"
+import { satisfies, lt } from "semver"
 import DBDestroySignal from "./libraries/AbortSignal"
 import { BinaryInfo, InternalServerOptions, ServerOptions } from '../types'
 import getBinaryURL from './libraries/Version'
@@ -9,6 +9,7 @@ import MySQLVersions from './versions.json'
 import { downloadBinary } from './libraries/Downloader'
 import { randomUUID } from "crypto";
 import {normalize as normalizePath} from 'path'
+import CONSTANTS from './constants'
 
 process.on('exit', () => {
     DBDestroySignal.abort('Process is exiting')
@@ -25,7 +26,8 @@ export async function createDB(opts?: ServerOptions) {
         username: 'root',
         deleteDBAfterStopped: true,
         //mysqlmsn = MySQL Memory Server Node.js
-        dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`)
+        dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`),
+        ignoreOutdatedSystemVersion: false
     }
     
     const options: InternalServerOptions = {...defaultOptions, ...opts}
@@ -35,8 +37,17 @@ export async function createDB(opts?: ServerOptions) {
     const executor = new Executor(logger)
 
     const version = await executor.getMySQLVersion(options.version)
+
+    const unsupportedMySQLIsInstalled = version && lt(version.version, CONSTANTS.MIN_SUPPORTED_MYSQL)
+
+    const throwUnsupportedError = unsupportedMySQLIsInstalled && !options.ignoreOutdatedSystemVersion
+
+    if (throwUnsupportedError) {
+        throw `A version of MySQL is installed on your system that is not supported by this package. If you want to download a MySQL binary instead of getting this error, please set the option "ignoreOutdatedSystemVersion" to true.`
+    }
+
     logger.log('Version currently installed:', version)
-    if (version === null || (options.version && !satisfies(version.version, options.version))) {
+    if (version === null || (options.version && !satisfies(version.version, options.version)) || unsupportedMySQLIsInstalled) {
         let binaryInfo: BinaryInfo;
         let binaryFilepath: string;
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export async function createDB(opts?: ServerOptions) {
         deleteDBAfterStopped: true,
         //mysqlmsn = MySQL Memory Server Node.js
         dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`),
-        ignoreOutdatedSystemVersion: false
+        ignoreUnsupportedSystemVersion: false
     }
     
     const options: InternalServerOptions = {...defaultOptions, ...opts}
@@ -40,15 +40,15 @@ export async function createDB(opts?: ServerOptions) {
 
     const unsupportedMySQLIsInstalled = version && lt(version.version, CONSTANTS.MIN_SUPPORTED_MYSQL)
 
-    const throwUnsupportedError = unsupportedMySQLIsInstalled && !options.ignoreOutdatedSystemVersion && !options.version
+    const throwUnsupportedError = unsupportedMySQLIsInstalled && !options.ignoreUnsupportedSystemVersion && !options.version
 
     if (throwUnsupportedError) {
-        throw `A version of MySQL is installed on your system that is not supported by this package. If you want to download a MySQL binary instead of getting this error, please set the option "ignoreOutdatedSystemVersion" to true.`
+        throw `A version of MySQL is installed on your system that is not supported by this package. If you want to download a MySQL binary instead of getting this error, please set the option "ignoreUnsupportedSystemVersion" to true.`
     }
 
     if (options.version && lt(options.version, CONSTANTS.MIN_SUPPORTED_MYSQL)) {
         //The difference between the throw here and the throw above is this throw is because the selected "version" is not supported.
-        //The throw above is because the system-installed MySQL is out of date and "ignoreOutdatedSystemVersion" is not set to true.
+        //The throw above is because the system-installed MySQL is out of date and "ignoreUnsupportedSystemVersion" is not set to true.
         throw `The selected version of MySQL (${options.version}) is not currently supported by this package. Please choose a different version to use.`
     }
 

--- a/stress-tests/stress.test.ts
+++ b/stress-tests/stress.test.ts
@@ -15,7 +15,8 @@ for (let i = 0; i < 100; i++) {
         const options: ServerOptions = {
             username: 'dbuser',
             logLevel: 'LOG',
-            deleteDBAfterStopped: !process.env.useCIDBPath
+            deleteDBAfterStopped: !process.env.useCIDBPath,
+            ignoreUnsupportedSystemVersion: true
         }
     
         if (process.env.useCIDBPath) {

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -15,7 +15,8 @@ beforeEach(async () => {
     const options: ServerOptions = {
         username: 'root',
         logLevel: 'LOG',
-        deleteDBAfterStopped: !process.env.useCIDBPath
+        deleteDBAfterStopped: !process.env.useCIDBPath,
+        ignoreUnsupportedSystemVersion: true
     }
 
     if (process.env.useCIDBPath) {

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -14,7 +14,7 @@ jest.setTimeout(500_000);
 for (const version of versions) {
     test(`running on version ${version}`, async () => {
         Error.stackTraceLimit = Infinity
-        const options: ServerOptions = {version, dbName: 'testingdata', username: 'root', logLevel: 'LOG', deleteDBAfterStopped: !process.env.useCIDBPath}
+        const options: ServerOptions = {version, dbName: 'testingdata', username: 'root', logLevel: 'LOG', deleteDBAfterStopped: !process.env.useCIDBPath, ignoreUnsupportedSystemVersion: true}
 
         if (process.env.useCIDBPath) {
             options.dbPath = `${dbPathPrefix}/${randomUUID()}`

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,7 +13,7 @@ export type ServerOptions = {
     username?: string,
     deleteDBAfterStopped?: boolean,
     dbPath?: string,
-    ignoreOutdatedSystemVersion?: boolean
+    ignoreUnsupportedSystemVersion?: boolean
 }
 
 export type InternalServerOptions = {
@@ -27,7 +27,7 @@ export type InternalServerOptions = {
     username: string,
     deleteDBAfterStopped: boolean,
     dbPath: string,
-    ignoreOutdatedSystemVersion: boolean
+    ignoreUnsupportedSystemVersion: boolean
 }
 
 export type ExecutorOptions = {

--- a/types/index.ts
+++ b/types/index.ts
@@ -12,7 +12,8 @@ export type ServerOptions = {
     lockRetryWait?: number,
     username?: string,
     deleteDBAfterStopped?: boolean,
-    dbPath?: string
+    dbPath?: string,
+    ignoreOutdatedSystemVersion?: boolean
 }
 
 export type InternalServerOptions = {
@@ -25,7 +26,8 @@ export type InternalServerOptions = {
     lockRetryWait: number,
     username: string,
     deleteDBAfterStopped: boolean,
-    dbPath: string
+    dbPath: string,
+    ignoreOutdatedSystemVersion: boolean
 }
 
 export type ExecutorOptions = {


### PR DESCRIPTION
This pull request closes #54

## Summary and Motivation

Motivation is mentioned in #54. Another change in this PR that is not covered by #54 is adding an option called `ignoreUnsupportedSystemVersion` so the package will download the MySQL binaries instead of using the system version so the package will still work on systems with non-supported MySQL versions

## Type of change

- [x] Bug Fix
- [x] Adding A Feature

## Checklist
Please make sure these steps are completed, or delete any irrelevant steps.

- [x] I have self-reviewed my code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch