### PR TITLE
Add Ubuntu 24.04 and newer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         # We only support Node.js 16 and newer
         node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         bun-version: [1.1.22]
 
     steps:
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Checkout
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Checkout
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ Download with your package manager of choice. The package name is `mysql-memory-
 #### Requirements
 
 - Node.js 16.6.0 and newer
-- macOS 13+, Windows, or Linux (Only Ubuntu has been tested. Other Linux distributions may or may not work at this time. Ubuntu 24.04 and newer is not fully supported at this time - go to the bottom of this file to learn more)
+- macOS 13+, Windows, or Linux (Only Ubuntu has been tested. Other Linux distributions may or may not work at this time.)
 
 Windows only requirements:
 - `Microsoft Visual C++ 2019 Redistributable Package` needs to be installed
 
 Linux only requirements:
-- The `libaio1` package needs to be installed
-- The `tar` package needs to be installed
+- The `libaio1` or `libaio1t64` package needs to be installed
+- If `libaio1` is not available but `libaio1t64` is, the `ldconfig` command needs to be available to run
+- The `tar` package needs to be installed if you want to use MySQL versions that aren't system installed
 
 Currently supported MySQL versions:
 - If using the system installed MySQL server: 8.0.20 and newer
@@ -169,7 +170,3 @@ Default: `TMPDIR/mysqlmsn/dbs/UUID` (replacing TMPDIR with the OS temp directory
 Gotchas: This option is intended to be for internal debugging purposes only and not meant for people to use. As such, this option will not follow Semantic Versioning.
 
 Description: The folder to store database-related data in
-
-## If using Ubuntu 24.04 and newer
-
-Selecting what MySQL version to use is not currently supported on Ubuntu 24.04 and newer. To use this package on Ubuntu 24.04 and newer you must have the `mysql-server` package installed on your system and `ServerOptions.version` must either be the version that is installed on the system or undefined.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "memory database"
   ],
   "scripts": {
-    "test": "jest --testPathIgnorePatterns=/stress-tests/",
+    "test": "jest --testPathIgnorePatterns=/stress-tests/ --verbose",
     "test:ci": "jest --testPathIgnorePatterns=/stress-tests/ --setupFilesAfterEnv ./ciSetup.js",
     "stress": "jest --runTestsByPath stress-tests/stress.test.ts --setupFilesAfterEnv ./ciSetup.js"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "scripts": {
     "test": "jest --testPathIgnorePatterns=/stress-tests/ --verbose",
-    "test:ci": "jest --testPathIgnorePatterns=/stress-tests/ --setupFilesAfterEnv ./ciSetup.js",
-    "stress": "jest --runTestsByPath stress-tests/stress.test.ts --setupFilesAfterEnv ./ciSetup.js"
+    "test:ci": "jest --testPathIgnorePatterns=/stress-tests/ --setupFilesAfterEnv ./ciSetup.js --verbose",
+    "stress": "jest --runTestsByPath stress-tests/stress.test.ts --setupFilesAfterEnv ./ciSetup.js --verbose"
   },
   "author": "Sebastian-Webster",
   "license": "MIT",

--- a/src/libraries/Downloader.ts
+++ b/src/libraries/Downloader.ts
@@ -7,8 +7,9 @@ import AdmZip from 'adm-zip'
 import { normalize as normalizePath } from 'path';
 import { randomUUID } from 'crypto';
 import { exec } from 'child_process';
-import { lockSync, checkSync, unlockSync } from 'proper-lockfile';
+import { lockSync, unlockSync } from 'proper-lockfile';
 import { BinaryInfo, InternalServerOptions } from '../../types';
+import { waitForLock } from './FileLock';
 
 function getZipData(entry: AdmZip.IZipEntry): Promise<Buffer> {
     return new Promise((resolve, reject) => {
@@ -137,26 +138,6 @@ function extractBinary(url: string, archiveLocation: string, extractedLocation: 
         }).catch(error => {
             reject(`An error occurred while extracting the tar file. Please make sure tar is installed and there is enough storage space for the extraction. The error was: ${error}`)
         })
-    })
-}
-
-function waitForLock(path: string, options: InternalServerOptions): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-        let retries = 0;
-        while (retries <= options.lockRetries) {
-            retries++
-            try {
-                const locked = checkSync(path);
-                if (!locked) {
-                    return resolve()
-                } else {
-                    await new Promise(resolve => setTimeout(resolve, options.lockRetryWait))
-                }
-            } catch (e) {
-                return reject(e)
-            }
-        }
-        reject(`lockRetries has been exceeded. Lock had not been released after ${options.lockRetryWait} * ${options.lockRetries} milliseconds.`)
     })
 }
 

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -249,7 +249,7 @@ class Executor {
     }
 
     #initializeDatabase(binaryFilepath: string, datadir: string): Promise<string> {
-        return new Promise(async (resolve, reject) => {
+        return new Promise(async resolve => {
             await fsPromises.mkdir(datadir, {recursive: true})
 
             this.logger.log('Created data directory for database at:', datadir)
@@ -267,10 +267,6 @@ class Executor {
 
             process.on('close', (code, signal) => {
                 this.logger.log('Database initialization process closed with code:', code, 'and signal:', signal)
-                if (code !== 0) {
-                    this.logger.error(stderr)
-                    reject('An error occurred while initializing database. Please check the console for more information.')
-                }
                 resolve(stderr)
             })
         })

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -272,7 +272,8 @@ class Executor {
                     }
                     const libaioFound = stdout.split('\n').filter(lib => lib.includes('libaio.so.1t64'))
                     if (!libaioFound.length) {
-                        throw 'libaio1 and libaio1t64 could not be found. Either libaio1 or libaio1t64 must be installed on this system for MySQL to run. To learn more, please check out https://dev.mysql.com/doc/refman/en/binary-installation.html'
+                        this.logger.error('Error from launching MySQL:', err || stderr)
+                        throw 'An error occurred while launching MySQL. The most likely cause is that libaio1 and libaio1t64 could not be found. Either libaio1 or libaio1t64 must be installed on this system for MySQL to run. To learn more, please check out https://dev.mysql.com/doc/refman/en/binary-installation.html. Check error in console for more information.'
                     }
                     const libaioEntry = libaioFound[0]
                     const libaioPathIndex = libaioEntry.indexOf('=>')

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -279,11 +279,6 @@ class Executor {
             }
             stderr = result?.stderr
         }
-
-        if (retry === false) {
-            this.logger.warn('Retry is false and stderr is:', stderr)
-            this.logger.warn(stderr && !stderr.includes('InnoDB initialization has ended'))
-        }
             
         if (stderr && !stderr.includes('InnoDB initialization has ended')) {
             if (process.platform === 'win32' && stderr.includes('Command failed')) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -270,8 +270,14 @@ class Executor {
                 throw 'An error occurred while initializing database with system-installed MySQL. Please check the console for more information.'
             }
         } else {
-            const result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], resolvePath(`${binaryFilepath}/..`))
-            stderr = result.stderr
+            let result: {stderr: string, stdout: string};
+            try {
+                result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], resolvePath(`${binaryFilepath}/..`))
+            } catch (e) {
+                this.logger.error('Error occurred from executeFile:', e)
+                throw e
+            }
+            stderr = result?.stderr
         }
 
         if (retry === false) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -301,12 +301,13 @@ class Executor {
                         } catch (e) {
                             copyError = e
                             this.logger.error('An error occurred while copying libaio1t64 to lib folder:', e)
-                        } finally {
+
                             try {
                                 await fsPromises.rm(copyPath, {force: true})
                             } catch (e) {
                                 this.logger.error('An error occurred while deleting libaio file:', e)
                             }
+                        } finally {
 
                             try {
                                 unlockSync(copyPath, {realpath: false})

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -261,6 +261,7 @@ class Executor {
             }
 
             if (process.platform === 'linux' && (err?.message.includes('libaio.so') || stderr.includes('libaio.so'))) {
+                this.logger.log('Handling error that occurred because of libaio...')
                 if (binaryFilepath === 'mysqld') {
                     throw 'libaio could not be found while running system-installed MySQL. libaio must be installed on this system for MySQL to run. To learn more, please check out https://dev.mysql.com/doc/refman/en/binary-installation.html'
                 }
@@ -318,6 +319,7 @@ class Executor {
                     }
                     
                     //Retry setting up directory now that libaio has been copied
+                    this.logger.log('Retrying directory setup')
                     await this.deleteDatabaseDirectory(datadir)
                     await this.#setupDataDirectories(options, binaryFilepath, datadir)
                 } else {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -255,7 +255,7 @@ class Executor {
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(binaryFilepath, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir, shell: true})
+            const process = spawn(`"binaryFilepath"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir, shell: true})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -284,14 +284,16 @@ class Executor {
                     }
                     const libaioEntry = libaioFound[0]
                     const libaioPathIndex = libaioEntry.indexOf('=>')
-                    const libaioPath = libaioEntry.slice(libaioPathIndex + 3)
+                    const libaioSymlinkPath = libaioEntry.slice(libaioPathIndex + 3)
+
+                    const libaioPath = await fsPromises.readlink(libaioSymlinkPath)
 
                     const copyPath = resolvePath(`${binaryFilepath}/../../lib/private/libaio.so.1`)
 
                     try {
                         lockSync(copyPath, {realpath: false})
 
-                        this.logger.log('libaio copy path:', copyPath)
+                        this.logger.log('libaio copy path:', copyPath, '| libaio symlink path:', libaioSymlinkPath, '| libaio actual path:', libaioPath)
                         let copyError: Error;
 
                         try {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -255,7 +255,7 @@ class Executor {
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(`"binaryFilepath"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir, shell: true})
+            const process = spawn(`"binaryFilepath"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -252,7 +252,7 @@ class Executor {
         return new Promise((resolve, reject) => {
             let stderr = ''
 
-            const process = spawn(binaryFilepath, ['--no-defaults', ` --datadir=${datadir}`, '--initialize-insecure'])
+            const process = spawn(binaryFilepath, [`--no-defaults --datadir=${datadir} --initialize-insecure`])
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -393,6 +393,7 @@ class Executor {
 
         do {
             await this.#setupDataDirectories(options, binaryFilepath, datadir, true);
+            this.logger.log('Setting up directories was successful')
 
             const port = GenerateRandomPort()
             const mySQLXPort = GenerateRandomPort();

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -261,7 +261,7 @@ class Executor {
             }
 
             if (process.platform === 'linux' && (err?.message.includes('libaio.so') || stderr.includes('libaio.so'))) {
-                this.logger.log('An error occurred while initializing database:', err || stderr)
+                this.logger.error('An error occurred while initializing database:', err || stderr)
                 if (binaryFilepath === 'mysqld') {
                     throw 'libaio could not be found while running system-installed MySQL. libaio must be installed on this system for MySQL to run. To learn more, please check out https://dev.mysql.com/doc/refman/en/binary-installation.html'
                 }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -249,7 +249,7 @@ class Executor {
     }
 
     #initializeDatabase(binaryFilepath: string, datadir: string): Promise<string> {
-        return new Promise(async resolve => {
+        return new Promise(async (resolve, reject) => {
             await fsPromises.mkdir(datadir, {recursive: true})
 
             this.logger.log('Created data directory for database at:', datadir)
@@ -268,6 +268,11 @@ class Executor {
             process.on('close', (code, signal) => {
                 this.logger.log('Database initialization process closed with code:', code, 'and signal:', signal)
                 resolve(stderr)
+            })
+
+            process.on('error', (e) => {
+                this.logger.error('An error occurred while initializing database:', e)
+                reject('An error occurred while initializing database. Please check the console for more information.')
             })
         })
     }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -365,13 +365,19 @@ class Executor {
             throw stderr
         }
 
+        this.logger.log('Creating init text')
+
         let initText = `CREATE DATABASE ${options.dbName};`;
 
         if (options.username !== 'root') {
             initText += `\nRENAME USER 'root'@'localhost' TO '${options.username}'@'localhost';`
         }
 
+        this.logger.log('Writing init file')
+
         await fsPromises.writeFile(`${options.dbPath}/init.sql`, initText, {encoding: 'utf8'})
+
+        this.logger.log('Finished writing init file')
     }
 
     async startMySQL(options: InternalServerOptions, binaryFilepath: string): Promise<MySQLDB> {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -250,6 +250,7 @@ class Executor {
 
     #initializeDatabase(binaryFilepath: string, datadir: string): Promise<string> {
         return new Promise((resolve, reject) => {
+            this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
             const process = spawn(binaryFilepath, [`--no-defaults --datadir=${datadir} --initialize-insecure`])
@@ -274,7 +275,6 @@ class Executor {
     }
 
     async #setupDataDirectories(options: InternalServerOptions, binaryFilepath: string, datadir: string, retry: boolean): Promise<void> {
-        this.logger.log('Created data directory for database at:', datadir)
         await fsPromises.mkdir(datadir, {recursive: true})
 
         const stderr = await this.#initializeDatabase(binaryFilepath, datadir)

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -355,6 +355,7 @@ class Executor {
                             await waitForLock(copyPath, options)
                             this.logger.log('Lock is gone for libaio copy')
                         }
+                        this.logger.error('An error occurred from locking libaio section:', error)
                         throw error
                     }
                 } else {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -255,7 +255,7 @@ class Executor {
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(`"binaryFilepath"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir})
+            const process = spawn(`"${binaryFilepath}"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -318,6 +318,7 @@ class Executor {
                     }
                     
                     //Retry setting up directory now that libaio has been copied
+                    await this.deleteDatabaseDirectory(datadir)
                     await this.#setupDataDirectories(options, binaryFilepath, datadir)
                 } else {
                     throw 'Cannot recognize file structure for the MySQL binary folder. This was caused by not being able to find libaio. Try installing libaio. Learn more at https://dev.mysql.com/doc/refman/en/binary-installation.html'

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -29,7 +29,7 @@ class Executor {
     #executeFile(command: string, args: string[], cwd: string): Promise<{stdout: string, stderr: string}> {
         return new Promise(resolve => {
             execFile(command, args, {signal: DBDestroySignal.signal, shell: true, cwd}, (error, stdout, stderr) => {
-                resolve({stdout, stderr: error.message || stderr})
+                resolve({stdout, stderr: error?.message || stderr})
             })
         })
     }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -30,6 +30,7 @@ class Executor {
         return new Promise((resolve, reject) => {
             execFile(command, args, {signal: DBDestroySignal.signal}, (error, stdout, stderr) => {
                 if (error) {
+                    this.logger.error('An error occurred while executing a file:', error)
                     return reject(error)
                 }
 

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -275,7 +275,7 @@ class Executor {
                 throw 'An error occurred while initializing database with system-installed MySQL. Please check the console for more information.'
             }
         } else {
-            const result = await this.#executeFile(`"${binaryFilepath}"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`])
+            const result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`])
             stderr = result.stderr
         }
             

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -28,7 +28,7 @@ class Executor {
 
     #executeFile(command: string, args: string[]): Promise<{stdout: string, stderr: string}> {
         return new Promise((resolve, reject) => {
-            execFile(command, args, {signal: DBDestroySignal.signal}, (error, stdout, stderr) => {
+            execFile(command, args, {signal: DBDestroySignal.signal, shell: true}, (error, stdout, stderr) => {
                 if (error) {
                     this.logger.error('An error occurred while executing a file:', error)
                     return reject(error)

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -286,7 +286,7 @@ class Executor {
                     const libaioPathIndex = libaioEntry.indexOf('=>')
                     const libaioSymlinkPath = libaioEntry.slice(libaioPathIndex + 3)
 
-                    const libaioPath = await fsPromises.readlink(libaioSymlinkPath)
+                    const libaioPath = await fsPromises.realpath(libaioSymlinkPath)
 
                     const copyPath = resolvePath(`${binaryFilepath}/../../lib/private/libaio.so.1`)
 

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -292,12 +292,12 @@ class Executor {
             }
 
             if (process.platform === 'linux' && stderr.includes('libaio.so')) {
-                this.logger.error('An error occurred while initializing database:', stderr)
                 if (binaryFilepath === 'mysqld') {
                     throw 'libaio could not be found while running system-installed MySQL. libaio must be installed on this system for MySQL to run. To learn more, please check out https://dev.mysql.com/doc/refman/en/binary-installation.html'
                 }
 
                 if (retry === false) {
+                    this.logger.error('An error occurred while initializing database:', stderr)
                     throw 'Tried to copy libaio into lib folder and MySQL is still failing to initialize. Please check the console for more information.'
                 }
 

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -255,7 +255,7 @@ class Executor {
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(`"${binaryFilepath}"`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir})
+            const process = spawn(os.platform() === 'win32' ? 'mysqld.exe' : 'mysqld', [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -284,7 +284,7 @@ class Executor {
                     const copyPath = resolvePath(`${binaryFilepath}/../../lib/private/libaio.so.1`)
 
                     try {
-                        lockSync(copyPath)
+                        lockSync(copyPath, {realpath: false})
 
                         if (fs.existsSync(copyPath)) {
                             //If this ever gets called, that means even after copying libaio into the folder, there is still some libaio related error.

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -309,7 +309,7 @@ class Executor {
                             }
 
                             try {
-                                unlockSync(copyPath)
+                                unlockSync(copyPath, {realpath: false})
                             } catch (e) {
                                 this.logger.error('Error unlocking libaio file:', e)
                             }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -276,7 +276,7 @@ class Executor {
 
         if (retry === false) {
             this.logger.warn('Retry is false and stderr is:', stderr)
-            this.logger.warn(!stderr.includes('InnoDB initialization has ended'))
+            this.logger.warn(stderr && !stderr.includes('InnoDB initialization has ended'))
         }
             
         if (stderr && !stderr.includes('InnoDB initialization has ended')) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -273,6 +273,10 @@ class Executor {
             const result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], resolvePath(`${binaryFilepath}/..`))
             stderr = result.stderr
         }
+
+        if (retry === false) {
+            this.logger.warn('Retry is false and stderr is:', stderr)
+        }
             
         if (stderr && !stderr.includes('InnoDB initialization has ended')) {
             if (process.platform === 'win32' && stderr.includes('Command failed')) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -249,11 +249,13 @@ class Executor {
     }
 
     #initializeDatabase(binaryFilepath: string, datadir: string): Promise<string> {
-        return new Promise((resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
+            await fsPromises.mkdir(datadir, {recursive: true})
+
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(binaryFilepath, [`--no-defaults --datadir=${datadir} --initialize-insecure`], {cwd: datadir})
+            const process = spawn(binaryFilepath, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], {cwd: datadir, shell: true})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {
@@ -275,8 +277,6 @@ class Executor {
     }
 
     async #setupDataDirectories(options: InternalServerOptions, binaryFilepath: string, datadir: string, retry: boolean): Promise<void> {
-        await fsPromises.mkdir(datadir, {recursive: true})
-
         const stderr = await this.#initializeDatabase(binaryFilepath, datadir)
             
         if (stderr && !stderr.includes('InnoDB initialization has ended')) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -309,7 +309,7 @@ class Executor {
                             }
 
                             try {
-                                unlockSync(copyPath, {realpath: false})
+                                unlockSync(copyPath)
                             } catch (e) {
                                 this.logger.error('Error unlocking libaio file:', e)
                             }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -26,9 +26,9 @@ class Executor {
         })
     }
 
-    #executeFile(command: string, args: string[]): Promise<{stdout: string, stderr: string}> {
+    #executeFile(command: string, args: string[], cwd: string): Promise<{stdout: string, stderr: string}> {
         return new Promise((resolve, reject) => {
-            execFile(command, args, {signal: DBDestroySignal.signal, shell: true}, (error, stdout, stderr) => {
+            execFile(command, args, {signal: DBDestroySignal.signal, shell: true, cwd}, (error, stdout, stderr) => {
                 if (error) {
                     this.logger.error('An error occurred while executing a file:', error)
                     return reject(error)
@@ -275,7 +275,7 @@ class Executor {
                 throw 'An error occurred while initializing database with system-installed MySQL. Please check the console for more information.'
             }
         } else {
-            const result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`])
+            const result = await this.#executeFile(`${binaryFilepath}`, [`--no-defaults`, `--datadir=${datadir}`, `--initialize-insecure`], resolvePath(`${binaryFilepath}/..`))
             stderr = result.stderr
         }
             

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -28,7 +28,7 @@ class Executor {
 
     #executeFile(command: string, args: string[], cwd: string): Promise<{stdout: string, stderr: string}> {
         return new Promise(resolve => {
-            execFile(command, args, {signal: DBDestroySignal.signal, shell: true, cwd}, (error, stdout, stderr) => {
+            execFile(command, args, {signal: DBDestroySignal.signal, cwd}, (error, stdout, stderr) => {
                 resolve({stdout, stderr: error?.message || stderr})
             })
         })

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -27,14 +27,9 @@ class Executor {
     }
 
     #executeFile(command: string, args: string[], cwd: string): Promise<{stdout: string, stderr: string}> {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
             execFile(command, args, {signal: DBDestroySignal.signal, shell: true, cwd}, (error, stdout, stderr) => {
-                if (error) {
-                    this.logger.error('An error occurred while executing a file:', error)
-                    return reject(error)
-                }
-
-                resolve({stdout, stderr})
+                resolve({stdout, stderr: error.message || stderr})
             })
         })
     }

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -253,7 +253,7 @@ class Executor {
             this.logger.log('Created data directory for database at:', datadir)
             let stderr = ''
 
-            const process = spawn(binaryFilepath, [`--no-defaults --datadir=${datadir} --initialize-insecure`])
+            const process = spawn(binaryFilepath, [`--no-defaults --datadir=${datadir} --initialize-insecure`], {cwd: datadir})
 
             process.stderr.on('data', (data) => {
                 if (Buffer.isBuffer(data)) {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -354,6 +354,7 @@ class Executor {
                             this.logger.log('Retrying directory setup')
                             await this.deleteDatabaseDirectory(datadir)
                             await this.#setupDataDirectories(options, binaryFilepath, datadir, false)
+                            return
                         }
                     } catch (error) {
                         if (String(error) === 'Error: Lock file is already being held') {

--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -276,6 +276,7 @@ class Executor {
 
         if (retry === false) {
             this.logger.warn('Retry is false and stderr is:', stderr)
+            this.logger.warn(!stderr.includes('InnoDB initialization has ended'))
         }
             
         if (stderr && !stderr.includes('InnoDB initialization has ended')) {

--- a/src/libraries/FileLock.ts
+++ b/src/libraries/FileLock.ts
@@ -1,0 +1,22 @@
+import { checkSync } from "proper-lockfile";
+import { InternalServerOptions } from "../../types";
+
+export function waitForLock(path: string, options: InternalServerOptions): Promise<void> {
+    return new Promise(async (resolve, reject) => {
+        let retries = 0;
+        while (retries <= options.lockRetries) {
+            retries++
+            try {
+                const locked = checkSync(path);
+                if (!locked) {
+                    return resolve()
+                } else {
+                    await new Promise(resolve => setTimeout(resolve, options.lockRetryWait))
+                }
+            } catch (e) {
+                return reject(e)
+            }
+        }
+        reject(`lockRetries has been exceeded. Lock had not been released after ${options.lockRetryWait} * ${options.lockRetries} milliseconds.`)
+    })
+}


### PR DESCRIPTION
This pull request closes #24

## Summary and Motivation

The goal is to get this package to run on systems that run on Ubuntu 24.04 and newer. The reason why it doesn't currently work on Ubuntu 24.04 and newer is explained in #24. 

The plan to get it to work as of now is to check if libaio1 and libaio1t64 are installed. If none are installed, an informative error will be given telling the user to install libaio. If one of them are installed, it will try running MySQL, and if it fails because of a libaio error, it will copy the libaio1t64 shared library file into the `lib` folder in the MySQL server folder so `mysqld` can find it and then re-run MySQL.

We could copy the shared library file into the server folder before running MySQL, but if/when MySQL adds support for libaio1t64 we wouldn't want to do the unnecessary copy since MySQL would support libaio1t64 out of the box.

## Type of change

- [x] Adding A Feature