### PR TITLE
Add validateChecksums option

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Default: false
 
 Description: This option only applies if the system-installed MySQL version is lower than the oldest supported MySQL version for this package (8.0.20) and the `version` option is not defined. If set to `true`, this package will use the latest version of MySQL instead of the system-installed version. If `false`, the package will throw an error.
 
+- `validateChecksums: boolean`
+
+Required: No
+
+Default: true
+
+Description: If set to `true`, the MD5 checksum is validated for any downloaded MySQL binaries and an error is thrown if the checksums do not match.
+
 - `deleteDBAfterStopped: boolean`
 
 Required: No

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ export async function createDB(opts?: ServerOptions) {
         dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`),
         ignoreUnsupportedSystemVersion: false,
         port: 0,
-        xPort: 0
+        xPort: 0,
+        validateChecksums: true
     }
     
     const options: InternalServerOptions = {...defaultOptions, ...opts}

--- a/src/libraries/Downloader.ts
+++ b/src/libraries/Downloader.ts
@@ -180,18 +180,31 @@ export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOp
                 return resolve(binaryPath)
             }
 
-            try {
-                lockSync(extractedPath)
-            } catch (e) {
-                if (String(e).includes('Lock file is already being held')) {
-                    logger.log('Waiting for lock for MySQL version', version)
-                    await waitForLock(extractedPath, options)
-                    logger.log('Lock is gone for version', version)
-                    return resolve(binaryPath)
+            let retry: boolean;
+            do {
+                try {
+                    lockSync(extractedPath)
+                    retry = false
+                } catch (e) {
+                    if (String(e).includes('Lock file is already being held')) {
+                        logger.log('Waiting for lock for MySQL version', version)
+                        await waitForLock(extractedPath, options)
+                        const binaryExists = fs.existsSync(binaryPath)
+                        if (!binaryExists) {
+                            //This will only happen if an error occurs during extraction or if the checksum is wrong.
+                            //If the binary doesn't exist after the lock is unlocked, the lock acquisition process should be retried
+                            retry = true;
+                            continue;
+                        } else {
+                            retry = false;
+                        }
+                        logger.log('Lock is gone for version', version)
+                        return resolve(binaryPath)
+                    }
+    
+                    return reject(e)
                 }
-
-                return reject(e)
-            }
+            } while (retry === true)
 
             //Code from this comment and below runs only if the lock has been successfully acquired
 
@@ -200,8 +213,8 @@ export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOp
             } catch (e) {
                 logger.error('An error occurred while downloading binary:', e)
                 try {
-                    unlockSync(extractedPath)
                     await fsPromises.rm(archivePath, {force: true, recursive: true})
+                    unlockSync(extractedPath)
                 } catch (e) {
                     logger.error(e)
                 } finally {
@@ -212,7 +225,16 @@ export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOp
             if (options.validateChecksums) {
                 const wrongChecksum = await checksumIsValid(archivePath, binaryInfo.checksum)
                 if (wrongChecksum) {
-                    throw new Error(`The checksum for the MySQL binary doesn't match the checksum in versions.json! Expected: ${binaryInfo.checksum} but got: ${wrongChecksum}`)
+                    try {
+                        await fsPromises.rm(archivePath, {force: true, recursive: true})
+                        unlockSync(extractedPath)
+                    } catch (e) {
+                        logger.error(e)
+                    } finally {
+                        return reject(new Error(`The checksum for the MySQL binary doesn't match the checksum in versions.json! Expected: ${binaryInfo.checksum} but got: ${wrongChecksum}`))
+                    }
+                } else {
+                    logger.log('Correct checksum was found for version:', binaryInfo.version)
                 }
             }
 

--- a/src/libraries/Version.ts
+++ b/src/libraries/Version.ts
@@ -32,6 +32,7 @@ export default function getBinaryURL(versions: MySQLVersion[], versionToGet: str
 
     return {
         url: v.url,
-        version: v.version
+        version: v.version,
+        checksum: v.checksum
     }
 }

--- a/src/versions.json
+++ b/src/versions.json
@@ -5,7 +5,7 @@
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
         "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-arm64.tar.gz",
-        "checksum": "1d447e95e748b2d8d7f07986aa2318e8"
+        "checksum": "1d447e95e748b2d8d7f07986aa2318e9"
     },
     {
         "version": "9.0.1",

--- a/src/versions.json
+++ b/src/versions.json
@@ -5,7 +5,7 @@
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
         "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-arm64.tar.gz",
-        "checksum": "1d447e95e748b2d8d7f07986aa2318e9"
+        "checksum": "1d447e95e748b2d8d7f07986aa2318e8"
     },
     {
         "version": "9.0.1",

--- a/src/versions.json
+++ b/src/versions.json
@@ -4,209 +4,239 @@
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-arm64.tar.gz",
+        "checksum": "1d447e95e748b2d8d7f07986aa2318e9"
     },
     {
         "version": "9.0.1",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-macos14-x86_64.tar.gz",
+        "checksum": "8b578fc73c854a2bef1dd8ee1cc50ffd"
     },
     {
         "version": "9.0.1",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "6d1b40d3f39f0cc098fcfe846c52008c"
     },
     {
         "version": "9.0.1",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "af79a3f055617669a4d2fe50a1a79ce8"
     },
     {
         "version": "9.0.1",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-9.0/mysql-9.0.1-winx64.zip",
+        "checksum": "bfba039694efb85916830cf9dc65ccc8"
     },
     {
         "version": "8.4.2",
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-macos14-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-macos14-arm64.tar.gz",
+        "checksum": "503babfaceedf024c99f722824ab054c"
     },
     {
         "version": "8.4.2",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-macos14-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-macos14-x86_64.tar.gz",
+        "checksum": "f8226460536f4b4f21ceff20cd419944"
     },
     {
         "version": "8.4.2",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "ad70726bfb4089620d03772e36238e0c"
     },
     {
         "version": "8.4.2",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "0009cef755fd334eaa3b011d04706d13"
     },
     {
         "version": "8.4.2",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.2-winx64.zip",
+        "checksum": "9aad84967d8a94c390e76366ca85ec3c"
     },
     {
         "version": "8.0.39",
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-macos14-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-macos14-arm64.tar.gz",
+        "checksum": "4535354d24b7dac72da93d60181d6d64"
     },
     {
         "version": "8.0.39",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-macos14-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-macos14-x86_64.tar.gz",
+        "checksum": "6a050fb7b5649bfa4109ade2a76e1b39"
     },
     {
         "version": "8.0.39",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "8b268e53998e662d46dfc57292e08993"
     },
     {
         "version": "8.0.39",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "b0f86747e6cd9ebe1b0b62087f0e276e"
     },
     {
         "version": "8.0.39",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.39-winx64.zip",
+        "checksum": "acee83dd1f2fbd0317cf0cee9ddc4f10"
     },
     {
         "version": "8.1.0",
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-macos13-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-macos13-arm64.tar.gz",
+        "checksum": "420fe4563ff32ce50b841c8aab013e07"
     },
     {
         "version": "8.1.0",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-macos13-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-macos13-x86_64.tar.gz",
+        "checksum": "71e17307da6cf992ae75931efe3e7069"
     },
     {
         "version": "8.1.0",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "bc9573e67f1000832fd79a29e9dbf366"
     },
     {
         "version": "8.1.0",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "2c4183ff12982f2da1884dd36377e90e"
     },
     {
         "version": "8.1.0",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-winx64.zip",
+        "checksum": "40a977d01e565b1d751ca068c823ba16"
     },
     {
         "version": "8.2.0",
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-macos13-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-macos13-arm64.tar.gz",
+        "checksum": "c6d8b46d8921d030b28dd0d418862775"
     },
     {
         "version": "8.2.0",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-macos13-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-macos13-x86_64.tar.gz",
+        "checksum": "ccb6c86bc5c4b84522b6c196e48ac174"
     },
     {
         "version": "8.2.0",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "c1ec30f30d1c94a3d55274c0ec46c0b2"
     },
     {
         "version": "8.2.0",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "d2c90518925685907beb810f99f00e4f"
     },
     {
         "version": "8.2.0",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.2/mysql-8.2.0-winx64.zip",
+        "checksum": "e0b9ac00cf136a40020e579a33d080db"
     },
     {
         "version": "8.3.0",
         "arch": "arm64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-macos14-arm64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-macos14-arm64.tar.gz",
+        "checksum": "91e27c74be8aa53eeb20d31017752654"
     },
     {
         "version": "8.3.0",
         "arch": "x64",
         "os": "darwin",
         "osKernelVersionsSupported": ">=22",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-macos14-x86_64.tar.gz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-macos14-x86_64.tar.gz",
+        "checksum": "5b0f552ac632865cf1fbb71c47eafaee"
     },
     {
         "version": "8.3.0",
         "arch": "x64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-linux-glibc2.17-x86_64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-linux-glibc2.17-x86_64-minimal.tar.xz",
+        "checksum": "456d6c3cb80814adfce29995ce3f2718"
     },
     {
         "version": "8.3.0",
         "arch": "arm64",
         "os": "linux",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-linux-glibc2.17-aarch64-minimal.tar.xz"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-linux-glibc2.17-aarch64-minimal.tar.xz",
+        "checksum": "151b0ad5f35e438b50dd67fb5c027cf6"
     },
     {
         "version": "8.3.0",
         "arch": "x64",
         "os": "win32",
         "osKernelVersionsSupported": "*",
-        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-winx64.zip"
+        "url": "https://cdn.mysql.com//Downloads/MySQL-8.3/mysql-8.3.0-winx64.zip",
+        "checksum": "186efc230e44ded93b5aa89193a6fcbf"
     }
 ]

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -14,7 +14,7 @@ jest.setTimeout(500_000);
 
 for (const version of versions) {
     for (const username of usernames) {
-        test(`running on version ${version} with username ${username}`, async () => {
+        test.concurrent(`running on version ${version} with username ${username}`, async () => {
             Error.stackTraceLimit = Infinity
             const options: ServerOptions = {version, dbName: 'testingdata', username: username, logLevel: 'LOG', deleteDBAfterStopped: !process.env.useCIDBPath, ignoreUnsupportedSystemVersion: true}
     

--- a/types/index.ts
+++ b/types/index.ts
@@ -70,5 +70,6 @@ export type InstalledMySQLVersion = {
 
 export type BinaryInfo = {
     url: string,
-    version: string
+    version: string,
+    checksum: string
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,7 +15,8 @@ export type ServerOptions = {
     dbPath?: string,
     ignoreUnsupportedSystemVersion?: boolean,
     port?: number,
-    xPort?: number
+    xPort?: number,
+    validateChecksums?: boolean
 }
 
 export type InternalServerOptions = {
@@ -31,7 +32,8 @@ export type InternalServerOptions = {
     dbPath: string,
     ignoreUnsupportedSystemVersion: boolean,
     port: number,
-    xPort: number
+    xPort: number,
+    validateChecksums: boolean
 }
 
 export type ExecutorOptions = {
@@ -57,7 +59,8 @@ export type MySQLVersion = {
     arch: string,
     os: string,
     osKernelVersionsSupported: string,
-    url: string
+    url: string,
+    checksum: string
 }
 
 export type InstalledMySQLVersion = {


### PR DESCRIPTION
This pull request closes #65

## Summary and Motivation

This pull request adds the validateChecksums option requested from #65. This pull request also improves reliability for tests that use multiple databases as the lock acquisition is now retried if the binary does not exist after the lock has been released. If an error occurs while extracting the binary or if the checksum is invalid, the databases that are waiting for the lock to be released will now check if the binary exists before continuing. If it does not, it will restart the download process and acquire a new lock. Previous behaviour would make all databases using the same version fail to start if an error occurred during a download/checksum/extraction.

## Type of change

- [x] Bug Fix
- [x] Adding A Feature

## Checklist

- [x] I have self-reviewed my code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my change works
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch