### PR TITLE
Fix waiting for lock can throw errors

### DIFF
--- a/src/libraries/FileLock.ts
+++ b/src/libraries/FileLock.ts
@@ -7,7 +7,7 @@ export function waitForLock(path: string, options: InternalServerOptions): Promi
         while (retries <= options.lockRetries) {
             retries++
             try {
-                const locked = checkSync(path);
+                const locked = checkSync(path, {realpath: false});
                 if (!locked) {
                     return resolve()
                 } else {


### PR DESCRIPTION
This pull request closes #69

## Summary and Motivation

Added `realpath: false` to the options object so the lock is checked even if the file exists or not.

## Type of change

- [x] Bug Fix

## Checklist

- [x] I have self-reviewed my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] My branch is up to date with any changes from the main branch