### PR TITLE
Fix macOS 14 stress runners failing due to lack of storage space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,11 @@ jobs:
           docker-images: true
           swap-storage: false
 
+      - name: Free Disk Space (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        working-directory: /Applications
+        run: sudo find . -name Xcode\*.app -delete
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -208,7 +213,8 @@ jobs:
 
       - name: Free Disk Space (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: sudo rm -rf /Applications
+        working-directory: /Applications
+        run: sudo find . -name Xcode\*.app -delete
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
           docker-images: true
           swap-storage: false
 
+      - name: Free Disk Space (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: sudo rm -rf /Applications
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request closes #71

## Summary and Motivation

Xcode is not needed for this project so Xcode is deleted from the Applications folder to make room for the MySQL databases.

## Type of change

- [x] Bug Fix