### PR TITLE
Seperate Windows and non-Windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
 
     strategy:
       fail-fast: false
-      os: [windows-2019, windows-2022]
-      # We only support Node.js 16.6.0 and newer
-      node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
+      matrix:
+        os: [windows-2019, windows-2022]
+        # We only support Node.js 16.6.0 and newer
+        node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,45 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci-node:
+  ci-node-windows:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      os: [windows-2019, windows-2022]
+      # We only support Node.js 16.6.0 and newer
+      node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Upload test databases
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Databases-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: "C:\\Users\\RUNNER~1\\dbs"
+
+  ci-node-linux-and-mac:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        # We only support Node.js 16 and newer
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        # We only support Node.js 16.6.0 and newer
         node-version: [16.6.0, 16.x, 17.0.0, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
 
     steps:
@@ -32,27 +63,20 @@ jobs:
       - name: Run tests
         run: npm run test:ci
 
-      - name: Upload test dbs (Linux/macOS)
-        if: ${{ runner.os != 'Windows' && failure() }}
+      - name: Upload test databases
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Databases-${{ matrix.os }}-node${{ matrix.node-version }}
           path: /tmp/dbs
 
-      - name: Upload test dbs (Windows)
-        if: ${{ runner.os == 'Windows' && failure() }}
-        uses: actions/upload-artifact@v4.3.5
-        with:
-          name: Databases-${{ matrix.os }}-node${{ matrix.node-version }}
-          path: "C:\\Users\\RUNNER~1\\dbs"
-
-  ci-bun:
+  ci-bun-windows:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [windows-2019, windows-2022]
         bun-version: [1.1.22]
 
     steps:
@@ -70,28 +94,52 @@ jobs:
       - name: Run tests
         run: bun run test:ci
 
-      - name: Upload test dbs (Linux/macOS)
-        if: ${{ runner.os != 'Windows' && failure() }}
-        uses: actions/upload-artifact@v4.3.5
-        with:
-          name: Databases-${{ matrix.os }}-bun
-          path: /tmp/dbs
-
-      - name: Upload test dbs (Windows)
-        if: ${{ runner.os == 'Windows' && failure() }}
+      - name: Upload test databases
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Databases-${{ matrix.os }}-bun
           path: "C:\\Users\\RUNNER~1\\dbs"
 
-  test-node:
+  ci-bun-linux-and-mac:
     runs-on: ${{ matrix.os }}
-    needs: ci-node
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        bun-version: [1.1.22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun ${{ matrix.bun-version }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Install packages
+        run: bun install
+
+      - name: Run tests
+        run: bun run test:ci
+
+      - name: Upload test databases
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Databases-${{ matrix.os }}-bun
+          path: /tmp/dbs
+
+  test-node-windows:
+    runs-on: ${{ matrix.os }}
+    needs: ci-node-windows
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
 
     steps:
       - name: Checkout
@@ -108,14 +156,38 @@ jobs:
       - name: Run tests
         run: npm test
 
-  test-bun:
+  test-node-linux-and-mac:
     runs-on: ${{ matrix.os }}
-    needs: ci-bun
+    needs: ci-node-linux-and-mac
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  test-bun-windows:
+    runs-on: ${{ matrix.os }}
+    needs: ci-bun-windows
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
 
     steps:
       - name: Checkout
@@ -132,14 +204,69 @@ jobs:
       - name: Run tests
         run: bun run test
 
-  stress-node:
+  test-bun-linux-and-mac:
     runs-on: ${{ matrix.os }}
-    needs: test-node
+    needs: ci-bun-linux-and-mac
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun 1.1.22
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.22
+
+      - name: Install packages
+        run: bun install
+
+      - name: Run tests
+        run: bun run test
+
+  stress-node-windows:
+    runs-on: ${{ matrix.os }}
+    needs: test-node-windows
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Run tests
+        run: npm run stress
+
+      - name: Upload test databases
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTest-Databases-${{ matrix.os }}-node
+          path: "C:\\Users\\RUNNER~1\\dbs"
+
+  stress-node-linux-and-mac:
+    runs-on: ${{ matrix.os }}
+    needs: test-node-linux-and-mac
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -168,8 +295,8 @@ jobs:
       - name: Run tests
         run: npm run stress
 
-      - name: Upload test dbs (Linux/macOS)
-        if: ${{ runner.os != 'Windows' && failure() }}
+      - name: Upload test databases
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTest-Databases-${{ matrix.os }}-node
@@ -177,21 +304,45 @@ jobs:
             /tmp/dbs
             !/temp/dbs/*/*.sock
 
-      - name: Upload test dbs (Windows)
-        if: ${{ runner.os == 'Windows' && failure() }}
-        uses: actions/upload-artifact@v4.3.5
-        with:
-          name: StressTest-Databases-${{ matrix.os }}-node
-          path: "C:\\Users\\RUNNER~1\\dbs"
-
-  stress-bun:
+  stress-bun-windows:
     runs-on: ${{ matrix.os }}
-    needs: test-bun
+    needs: test-bun-windows
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [windows-2019, windows-2022]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun 1.1.22
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.22
+
+      - name: Install packages
+        run: bun install
+
+      - name: Run tests
+        run: bun run stress
+
+      - name: Upload test databases
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTest-Databases-${{ matrix.os }}-bun
+          path: "C:\\Users\\RUNNER~1\\dbs"
+
+  stress-bun-linux-and-mac:
+    runs-on: ${{ matrix.os }}
+    needs: test-bun-linux-and-mac
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -220,21 +371,14 @@ jobs:
       - name: Run tests
         run: bun run stress
 
-      - name: Upload test dbs (Linux/macOS)
-        if: ${{ runner.os != 'Windows' && failure() }}
+      - name: Upload test databases
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTest-Databases-${{ matrix.os }}-bun
           path: |
             /tmp/dbs
             !/temp/dbs/*/*.sock
-
-      - name: Upload test dbs (Windows)
-        if: ${{ runner.os == 'Windows' && failure() }}
-        uses: actions/upload-artifact@v4.3.5
-        with:
-          name: StressTest-Databases-${{ matrix.os }}-bun
-          path: "C:\\Users\\RUNNER~1\\dbs"
 
   fedora:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request closes #75

## Summary and Motivation

Motivation is explained in #75. This pull request splits the tests so Linux and macOS runs are in their own matrix.