### PR TITLE
Add binaryDirectoryPath option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Setup bun 1.1.22
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.22
+          bun-version: [1.1.22]
 
       - name: Install packages
         run: bun install
@@ -253,7 +253,7 @@ jobs:
       - name: Setup bun 1.1.22
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.22
+          bun-version: [1.1.22]
 
       - name: Install packages
         run: bun install
@@ -372,7 +372,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
-        bun-version: 1.1.22
+        bun-version: [1.1.22]
 
     steps:
       - name: Checkout
@@ -412,7 +412,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        bun-version: 1.1.22
+        bun-version: [1.1.22]
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Setup bun 1.1.22
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: [1.1.22]
+          bun-version: 1.1.22
 
       - name: Install packages
         run: bun install
@@ -253,7 +253,7 @@ jobs:
       - name: Setup bun 1.1.22
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: [1.1.22]
+          bun-version: 1.1.22
 
       - name: Install packages
         run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Binaries-${{ matrix.os }}-node${{ matrix.node-version }}
@@ -81,6 +82,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Binaries-${{ matrix.os }}-node${{ matrix.node-version }}
@@ -120,6 +122,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Binaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
@@ -159,6 +162,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Binaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
@@ -294,6 +298,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTestBinaries-${{ matrix.os }}-node${{ matrix.node-version }}
@@ -358,6 +363,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTestBinaries-${{ matrix.os }}-node${{ matrix.node-version }}
@@ -398,6 +404,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTestBinaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
@@ -463,6 +470,7 @@ jobs:
           compression-level: 9
 
       - name: Upload test binaries
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
           name: StressTestBinaries-${{ matrix.os }}-bun${{ matrix.bun-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,14 @@ jobs:
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Databases-${{ matrix.os }}-node${{ matrix.node-version }}
-          path: "C:\\Users\\RUNNER~1\\dbs"
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\dbs"
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Binaries-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\binaries"
           compression-level: 9
 
   ci-node-linux-and-mac:
@@ -70,7 +77,14 @@ jobs:
         uses: actions/upload-artifact@v4.3.5
         with:
           name: Databases-${{ matrix.os }}-node${{ matrix.node-version }}
-          path: /tmp/dbs
+          path: /tmp/mysqlmsn/dbs
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Binaries-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: /tmp/mysqlmsn/binaries
           compression-level: 9
 
   ci-bun-windows:
@@ -101,8 +115,15 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
-          name: Databases-${{ matrix.os }}-bun
-          path: "C:\\Users\\RUNNER~1\\dbs"
+          name: Databases-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\dbs"
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Binaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\binaries"
           compression-level: 9
 
   ci-bun-linux-and-mac:
@@ -133,8 +154,15 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
-          name: Databases-${{ matrix.os }}-bun
-          path: /tmp/dbs
+          name: Databases-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: /tmp/mysqlmsn/dbs
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: Binaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: /tmp/mysqlmsn/binaries
           compression-level: 9
 
   test-node-windows:
@@ -261,8 +289,15 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
-          name: StressTest-Databases-${{ matrix.os }}-node
-          path: "C:\\Users\\RUNNER~1\\dbs"
+          name: StressTestDatabases-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\dbs"
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTestBinaries-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\binaries"
           compression-level: 9
 
   stress-node-linux-and-mac:
@@ -318,8 +353,15 @@ jobs:
         with:
           name: StressTest-Databases-${{ matrix.os }}-node
           path: |
-            /tmp/dbs
-            !/temp/dbs/*/*.sock
+            /tmp/mysqlmsn/dbs
+            !/temp/mysqlmsn/dbs/*/*.sock
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTestBinaries-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: /tmp/mysqlmsn/binaries
           compression-level: 9
 
   stress-bun-windows:
@@ -330,15 +372,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
+        bun-version: 1.1.22
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup bun 1.1.22
+      - name: Setup bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.22
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install packages
         run: bun install
@@ -350,8 +393,15 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4.3.5
         with:
-          name: StressTest-Databases-${{ matrix.os }}-bun
-          path: "C:\\Users\\RUNNER~1\\dbs"
+          name: StressTestDatabases-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\dbs"
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTestBinaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: "C:\\Users\\RUNNER~1\\mysqlmsn\\binaries"
           compression-level: 9
 
   stress-bun-linux-and-mac:
@@ -362,6 +412,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, macos-14, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        bun-version: 1.1.22
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -390,10 +441,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup bun 1.1.22
+      - name: Setup bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.22
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install packages
         run: bun install
@@ -407,8 +458,15 @@ jobs:
         with:
           name: StressTest-Databases-${{ matrix.os }}-bun
           path: |
-            /tmp/dbs
-            !/temp/dbs/*/*.sock
+            /tmp/mysqlmsn/dbs
+            !/temp/mysqlmsn/dbs/*/*.sock
+          compression-level: 9
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@v4.3.5
+        with:
+          name: StressTestBinaries-${{ matrix.os }}-bun${{ matrix.bun-version }}
+          path: /tmp/mysqlmsn/binaries
           compression-level: 9
 
   fedora:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Description: This option only applies if the system-installed MySQL version is l
 
 #### :warning: Internal Options :warning:
 
-The following options are only meant for internal debugging use. Their behaviour may change between versions and they are not to be considered stable. The options below will not follow Semantic Versioning so it is advised to not modify their default values.
+The following options are only meant for internal debugging use. Their behaviour may change between versions and they are not to be considered stable. The options below will not follow Semantic Versioning so it is advised to not use them.
 
 - `deleteDBAfterStopped: boolean`
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,15 @@ Default: false
 
 Description: This option only applies if the system-installed MySQL version is lower than the oldest supported MySQL version for this package (8.0.20) and the `version` option is not defined. If set to `true`, this package will use the latest version of MySQL instead of the system-installed version. If `false`, the package will throw an error.
 
+#### :warning: Internal Options :warning:
+
+The following options are only meant for internal debugging use. Their behaviour may change between versions and they are not to be considered stable. The options below will not follow Semantic Versioning so it is advised to not modify their default values.
+
 - `deleteDBAfterStopped: boolean`
 
 Required: No
 
 Default: true
-
-Gotchas: This option is intended to be for internal debugging purposes only and not meant for people to use. As such, this option will not follow Semantic Versioning.
 
 Description: Changes whether or not the database will be deleted after it has been stopped. If set to `true`, the database WILL be deleted after it has been stopped.
 
@@ -200,8 +202,14 @@ Description: Changes whether or not the database will be deleted after it has be
 
 Required: No
 
-Default: `TMPDIR/mysqlmsn/dbs/UUID` (replacing TMPDIR with the OS temp directory and UUID with a UUIDv4 without seperating dashes)
-
-Gotchas: This option is intended to be for internal debugging purposes only and not meant for people to use. As such, this option will not follow Semantic Versioning.
+Default: `TMPDIR/mysqlmsn/dbs/UUID` (replacing TMPDIR with the OS temp directory and UUID with a UUIDv4 without seperating dashes).
 
 Description: The folder to store database-related data in
+
+- `binaryDirectoryPath: string`
+
+Required: No
+
+Default: `TMPDIR/mysqlmsn/binaries` (replacing TMPDIR with the OS temp directory)
+
+Description: The folder to store the MySQL binaries when they are downloaded from the CDN.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Default: false
 
 Description: This option only applies if the system-installed MySQL version is lower than the oldest supported MySQL version for this package (8.0.20) and the `version` option is not defined. If set to `true`, this package will use the latest version of MySQL instead of the system-installed version. If `false`, the package will throw an error.
 
-#### :warning: Internal Options :warning:
+***
+### :warning: Internal Options :warning:
 
 The following options are only meant for internal debugging use. Their behaviour may change between versions and they are not to be considered stable. The options below will not follow Semantic Versioning so it is advised to not use them.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,8 @@ export async function createDB(opts?: ServerOptions) {
         dbPath: normalizePath(`${os.tmpdir()}/mysqlmsn/dbs/${randomUUID().replace(/-/g, '')}`),
         ignoreUnsupportedSystemVersion: false,
         port: 0,
-        xPort: 0
+        xPort: 0,
+        binaryDirectoryPath: `${os.tmpdir()}/mysqlmsn/binaries`
     }
     
     const options: InternalServerOptions = {...defaultOptions, ...opts}

--- a/src/libraries/Downloader.ts
+++ b/src/libraries/Downloader.ts
@@ -148,7 +148,7 @@ function extractBinary(url: string, archiveLocation: string, extractedLocation: 
 export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOptions, logger: Logger): Promise<string> {
     return new Promise(async (resolve, reject) => {
         const {url, version} = binaryInfo;
-        const dirpath = `${os.tmpdir()}/mysqlmsn/binaries`
+        const dirpath = options.binaryDirectoryPath
         logger.log('Binary path:', dirpath)
         await fsPromises.mkdir(dirpath, {recursive: true})
 

--- a/stress-tests/stress.test.ts
+++ b/stress-tests/stress.test.ts
@@ -2,10 +2,13 @@ import {expect, test, jest} from '@jest/globals'
 import { createDB } from '../src/index'
 import sql from 'mysql2/promise'
 import { ServerOptions } from '../types';
+import { normalize } from 'path';
 
 jest.setTimeout(500_000);
 
-const dbPathPrefix = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\dbs' : '/tmp/dbs'
+const GitHubActionsTempFolder = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\mysqlmsn' : '/tmp/mysqlmsn'
+const dbPath = normalize(GitHubActionsTempFolder + '/dbs')
+const binaryPath = normalize(GitHubActionsTempFolder + '/binaries')
 
 for (let i = 0; i < 100; i++) {
     test.concurrent(`if run ${i} is successful`, async () => {
@@ -20,7 +23,8 @@ for (let i = 0; i < 100; i++) {
         }
     
         if (process.env.useCIDBPath) {
-            options.dbPath = `${dbPathPrefix}/${i}`
+            options.dbPath = `${dbPath}/${i}`
+            options.binaryDirectoryPath = binaryPath
         }
         
         const db = await createDB(options)

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -3,12 +3,15 @@ import { createDB } from '../src/index'
 import sql from 'mysql2/promise'
 import { MySQLDB, ServerOptions } from '../types';
 import { randomUUID } from 'crypto';
+import { normalize } from 'path';
 
 jest.setTimeout(500_000);
 
 let db: MySQLDB;
 
-const dbPathPrefix = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\dbs' : '/tmp/dbs'
+const GitHubActionsTempFolder = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\mysqlmsn' : '/tmp/mysqlmsn'
+const dbPath = normalize(GitHubActionsTempFolder + '/dbs')
+const binaryPath = normalize(GitHubActionsTempFolder + '/binaries')
 
 beforeEach(async () => {
     Error.stackTraceLimit = Infinity
@@ -20,7 +23,8 @@ beforeEach(async () => {
     }
 
     if (process.env.useCIDBPath) {
-        options.dbPath = `${dbPathPrefix}/${randomUUID()}`
+        options.dbPath = `${dbPath}/${randomUUID()}`
+        options.binaryDirectoryPath = binaryPath
     }
     
     db = await createDB(options)

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -4,11 +4,14 @@ import sql from 'mysql2/promise'
 import { coerce } from 'semver';
 import { randomUUID } from 'crypto';
 import { ServerOptions } from '../types';
+import { normalize } from 'path';
 
 const versions = ['9.0.1', '8.4.2', '8.0.39', '8.1.0', '8.2.0', '8.3.0']
 const usernames = ['root', 'dbuser', 'admin']
 
-const dbPathPrefix = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\dbs' : '/tmp/dbs'
+const GitHubActionsTempFolder = process.platform === 'win32' ? 'C:\\Users\\RUNNER~1\\mysqlmsn' : '/tmp/mysqlmsn'
+const dbPath = normalize(GitHubActionsTempFolder + '/dbs')
+const binaryPath = normalize(GitHubActionsTempFolder + '/binaries')
 
 jest.setTimeout(500_000);
 
@@ -19,7 +22,8 @@ for (const version of versions) {
             const options: ServerOptions = {version, dbName: 'testingdata', username: username, logLevel: 'LOG', deleteDBAfterStopped: !process.env.useCIDBPath, ignoreUnsupportedSystemVersion: true}
     
             if (process.env.useCIDBPath) {
-                options.dbPath = `${dbPathPrefix}/${randomUUID()}`
+                options.dbPath = `${dbPath}/${randomUUID()}`
+                options.binaryDirectoryPath = binaryPath
             }
     
             const db = await createDB(options)

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,7 +15,8 @@ export type ServerOptions = {
     dbPath?: string,
     ignoreUnsupportedSystemVersion?: boolean,
     port?: number,
-    xPort?: number
+    xPort?: number,
+    binaryDirectoryPath?: string
 }
 
 export type InternalServerOptions = {
@@ -31,7 +32,8 @@ export type InternalServerOptions = {
     dbPath: string,
     ignoreUnsupportedSystemVersion: boolean,
     port: number,
-    xPort: number
+    xPort: number,
+    binaryDirectoryPath: string
 }
 
 export type ExecutorOptions = {


### PR DESCRIPTION
This pull request closes #85

## Summary and Motivation

This pull request adds a `binaryDirectoryPath` option. This option takes a string, is not required, and WILL NOT be following Semantic Versioning as it is only meant for CI purposes. Changing this option will change where the MySQL binaries are stored.