### PR TITLE
Fix lock acquisition failure

### DIFF
--- a/src/libraries/Downloader.ts
+++ b/src/libraries/Downloader.ts
@@ -165,7 +165,6 @@ export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOp
 
         if (options.downloadBinaryOnce) {
             const extractedPath = `${dirpath}/${version}`
-            await fsPromises.mkdir(extractedPath, {recursive: true})
 
             const binaryPath = normalizePath(`${extractedPath}/mysql/bin/mysqld${process.platform === 'win32' ? '.exe' : ''}`)
             const archivePath = `${dirpath}/${version}.${fileExtension}`
@@ -180,6 +179,7 @@ export function downloadBinary(binaryInfo: BinaryInfo, options: InternalServerOp
 
             while (true) {
                 try {
+                    await fsPromises.mkdir(extractedPath, {recursive: true})
                     releaseFunction = lockSync(extractedPath)
                     break
                 } catch (e) {


### PR DESCRIPTION
This pull request closes #108

## Summary and Motivation

In the issue linked, it says the way to solve this would be to set realpath to false. In this pull request, the folder is made inside of the try block instead so then the folder will always be created.