### PR TITLE
Fix databases not starting in Windows Server 2025

### DIFF
--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -198,7 +198,7 @@ class Executor {
             })
 
             fs.watchFile(errorLogFile, async (curr) => {
-                if (curr.dev !== 0) {
+                if (curr.isFile()) {
                     //File exists
                     const file = await fsPromises.readFile(errorLogFile, {encoding: 'utf8'})
                     if (file.includes(': ready for connections') || file.includes('Server starts handling incoming connections')) {


### PR DESCRIPTION
This pull request closes #212

Use ```curr.isFile()``` instead of ```curr.dev``` for checking existence of the error log file.