### PR TITLE
Fix process already killed on Windows

### DIFF
--- a/src/libraries/Executor.ts
+++ b/src/libraries/Executor.ts
@@ -36,18 +36,10 @@ class Executor {
     }
 
     async #killProcess(process: ChildProcess): Promise<boolean> {
-        let killed = false;
-        if (os.platform() === 'win32') {
-            const {error, stderr} = await this.#executeFile('taskkill', ['/pid', String(process.pid), '/t', '/f'])
-            if (!error && !stderr) {
-                killed = true;
-            } else {
-                this.logger.error(error || stderr)
-            }
-        } else {
-            killed = process.kill()
-        }
-        return killed;
+        // If the process has already been killed, return true
+        if (process.kill(0) === false) return true
+
+        return process.kill()
     }
 
     //Returns a path to the binary if it should be deleted


### PR DESCRIPTION
There is a very rare chance that when killing the MySQL process after calling the ```stop()``` method, an error can be thrown because ```taskkill``` cannot kill the process as the process cannot be found. Before killing the process, a check is made to see if the process is already killed, and if it does there is an early return.

Instead of using ```taskkill``` for killing the process on Windows, all platforms will now use the Node.js ```process.kill()``` method.