### PR TITLE
Add macOS 26 tests

### DIFF
--- a/.github/workflows/os-compatibility.yml
+++ b/.github/workflows/os-compatibility.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15, ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, ubuntu-22.04-arm, ubuntu-24.04-arm, windows-11-arm]
+        os: [macos-13, macos-14, macos-15, macos-26, ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, ubuntu-22.04-arm, ubuntu-24.04-arm, windows-11-arm]
         #There is no 10.0.0 at the time of writing, but since greater than characters are not allowed in GitHub Actions artifacts names, 9.0.1 - 10.0.0 will be used instead of >9.0.0
         version-requirement: ['5.7.19 - 5.7.24', '5.7.25 - 5.7.29', '5.7.30 - 5.7.34', '5.7.35 - 5.7.39', '5.7.40 - 5.7.44', '8.0.0 - 8.0.4', '8.0.4 - 8.0.13', '8.0.14 - 8.0.19', '8.0.20 - 8.0.24', '8.0.25 - 8.0.29', '8.0.30 - 8.0.34', '8.0.35 - 8.0.39', '8.0.40 - 8.3.0', '8.4.0 - 9.0.0', '9.0.1 - 10.0.0']
 

--- a/docs/SUPPORTED_MYSQL_DOWNLOADS.md
+++ b/docs/SUPPORTED_MYSQL_DOWNLOADS.md
@@ -8,7 +8,7 @@
 - Windows
 - Linux
 
-*```mysql-memory-server``` gets tested on Ubuntu 22.04 (x64 and arm64) and 24.04 (x64 and arm64), Fedora 41 (x64 and arm64) and 42 (x64 and arm64), Alpine 3.22 (x64 and arm64), macOS 13 (x64), 14 (arm64), and 15 (arm64), Windows 11 (arm64), and Windows Server 2022 (x64) and 2025 (x64). Linux distributions and Windows and macOS versions other than the ones tested may or may not work and are not guaranteed to work with this package.*
+*```mysql-memory-server``` gets tested on Ubuntu 22.04 (x64 and arm64) and 24.04 (x64 and arm64), Fedora 41 (x64 and arm64) and 42 (x64 and arm64), Alpine 3.22 (x64 and arm64), macOS 13 (x64), 14 (arm64), 15 (arm64), and 26 (arm64), Windows 11 (arm64), and Windows Server 2022 (x64) and 2025 (x64). Linux distributions and Windows and macOS versions other than the ones tested may or may not work and are not guaranteed to work with this package.*
 
 ## Binaries not available for download
 


### PR DESCRIPTION
macOS 26 images for GitHub Actions are now in [public preview](https://github.com/actions/runner-images/issues/13008). This pull request adds macOS 26 tests to ensure there is testing for this package on macOS 26 systems.