### PR TITLE
Fix Alpine tests checking out wrong code

### DIFF
--- a/.github/workflows/os-compatibility.yml
+++ b/.github/workflows/os-compatibility.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Checkout code
         working-directory: mysqlmsn
-        run: git reset --hard ${{ github.sha }}
+        run: git reset --hard ${{ github.event.after }}
 
       - name: Install packages
         working-directory: mysqlmsn


### PR DESCRIPTION
This pull request closes #256

Before the most recent commit from the triggering branch was checked out. This is fine when there are only workflows triggered by the most recent commit. In cases where commits are made to a pull request in quick succession, the workflows in the queue may checkout the newer code by the time the workflow starts running. That leads to the workflow checking out the incorrect code, making it harder to track down behaviour changes when code is changing fast.

Now the workflow checks out all the history from the triggering branch, and then checks out the commit from the triggering commit SHA.